### PR TITLE
fix: fix bug with close authorization module after sucsess login

### DIFF
--- a/src/scripts/modules/authorization/view/AuthorizationView.ts
+++ b/src/scripts/modules/authorization/view/AuthorizationView.ts
@@ -73,7 +73,7 @@ export default class AuthorizationView extends ElementTemplate {
 
   showSignInErrors(str: string) {
     if (!str) {
-      this.accountOverlay.node.remove();
+      this.node.remove();
     } else if (str === '* Пользователь с таким email не существует') {
       this.signIn.emailError.node.textContent = str;
       this.signIn.passError.node.textContent = '';


### PR DESCRIPTION
После успешного логина не исчезал `overlay`, только само окно авторизации.