### PR TITLE
Fix/games layout

### DIFF
--- a/src/sass/base/_base.scss
+++ b/src/sass/base/_base.scss
@@ -30,8 +30,11 @@ body {
 .lock {
   overflow: hidden;
 }
-.hints {
+.hints,
+.rules {
   text-align: center;
-  margin-top: 30px;
+  margin-top: 15px;
   font-size: 16px;
+  color: $color-dark;
+  font-weight: 500;
 }

--- a/src/sass/layouts/_header.scss
+++ b/src/sass/layouts/_header.scss
@@ -7,6 +7,11 @@
   @include flex($justify-content: space-between);
   margin: auto;
   padding: 20px 0;
+  height: 85px;
+
+  @include media-tablet {
+    padding: 13px 0;
+  }
 }
 
 .header__title {

--- a/src/sass/pages/_audioCall.scss
+++ b/src/sass/pages/_audioCall.scss
@@ -8,11 +8,13 @@
 
     background: url("../assets/images/bg-main-2.png") no-repeat;
     background-size: cover;
+    @include fontAtm(32px, $color-primary, bold);
 }
 
 .audio-board {
     @include flexColumn(center, center);
     gap: 40px;
+    padding: 0 10px;
 }
 .audio-board__question {
     @include flexColumn(center, center);
@@ -32,8 +34,9 @@
 }
 
 .audio-board__words-container {
-    @include flexRow(space-around, center);
+    @include flexRow(center, center);
     gap: 20px;
+    flex-wrap: wrap;
 }
 
 .audio-board__word-ru {

--- a/src/sass/pages/_home.scss
+++ b/src/sass/pages/_home.scss
@@ -53,11 +53,12 @@
   max-width: 280px;
   border: 1px solid $color-dark;
   border-radius: 15px;
-  background-color: $color-light;
+  background-color: $color-primary;
   position: relative;
   overflow: hidden;
   @extend %transition;
   text-decoration: none;
+  height: 440px;
 
   &:before {
     @include pseudo;
@@ -87,6 +88,7 @@
   text-align: center;
   min-height: 120px;
   border-bottom: 25px solid $color-primary;
+  background-color: $color-light;
 }
 
 .item__subtitle {
@@ -108,6 +110,7 @@
   text-align: center;
   margin: 0;
   padding: 13px;
+  background-color: $color-light;
 }
 
 .team {

--- a/src/sass/pages/_sprint.scss
+++ b/src/sass/pages/_sprint.scss
@@ -253,7 +253,7 @@
 .sprint__timer {
   width: 70px;
   height: 70px;
-  top: 75px;
+  top: 145px;
   right: 10px;
   position: absolute;
   @include fontAtm(42px, $color-main, bold);

--- a/src/scripts/common/exit-svg.svg
+++ b/src/scripts/common/exit-svg.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<svg fill="white" height="45" viewBox="0 0 24 24" width="45" xmlns="http://www.w3.org/2000/svg">
+<svg fill="white" height="39" viewBox="0 0 24 24" width="39" xmlns="http://www.w3.org/2000/svg">
     <path clip-rule="evenodd" d="M14.5 12.5H2.5V11.5H14.5V12.5Z" fill="white" fill-rule="evenodd"/>
     <path clip-rule="evenodd"
           d="M11.3536 8.14645L14.8536 11.6465C15.0489 11.8417 15.0489 12.1583 14.8536 12.3536L11.3536 15.8536L10.6465 15.1465L13.7929 12L10.6465 8.85356L11.3536 8.14645Z"

--- a/src/scripts/modules/audioCall/view/AudioCallView.ts
+++ b/src/scripts/modules/audioCall/view/AudioCallView.ts
@@ -12,6 +12,8 @@ export default class AudioCallView extends ElementTemplate {
 
   hints: ElementTemplate | undefined;
 
+  rules: ElementTemplate | undefined;
+
   countDownWindow: CountDownWindow;
 
   waitingWindow: WaitingWindow;
@@ -75,6 +77,13 @@ export default class AudioCallView extends ElementTemplate {
     this.finishWindow.delete();
     this.node.append(this.board.node);
 
+    this.rules = new ElementTemplate(
+      null,
+      'div',
+      'rules',
+      '<b>Правила игры:</b><br> выберите из предложенных вариантов ответа правильный перевод услышанного слова',
+    );
+
     this.hints = new ElementTemplate(
       null,
       'div',
@@ -82,6 +91,7 @@ export default class AudioCallView extends ElementTemplate {
       'Управление с клавиатуры:<br> варианты ответов: <b>1-5</b><br>"Не знаю", "Далее", "Новая игра": <b>Space</b>',
     );
 
+    this.board.node.before(this.rules.node);
     this.board.node.after(this.hints.node);
   };
 

--- a/src/scripts/modules/audioCall/view/AudioCallView.ts
+++ b/src/scripts/modules/audioCall/view/AudioCallView.ts
@@ -23,7 +23,7 @@ export default class AudioCallView extends ElementTemplate {
   noWordsWindow: NoWordsWindow;
 
   constructor(parentNode: HTMLElement | null) {
-    super(parentNode, 'div', 'audiocall', '');
+    super(parentNode, 'div', 'audiocall', 'АУДИОВЫЗОВ');
     this.startWindow = new StartWindow(this.node);
     this.countDownWindow = new CountDownWindow(null);
     this.board = new Board(null);

--- a/src/scripts/modules/sprint/view/FinishWindow.ts
+++ b/src/scripts/modules/sprint/view/FinishWindow.ts
@@ -18,7 +18,7 @@ export default class FinishWindow extends ElementTemplate {
       this.node,
       'button',
       'btn finish__btn-play',
-      'Еще разок?',
+      'Новая игра',
     );
   }
 

--- a/src/scripts/modules/sprint/view/SprintView.ts
+++ b/src/scripts/modules/sprint/view/SprintView.ts
@@ -32,9 +32,11 @@ export default class SprintView extends ElementTemplate {
     this.countDownWindow = new CountDownWindow(null);
 
     this.boardContainer = new ElementTemplate(null, 'div', 'sprint__board-container');
+    new ElementTemplate(this.boardContainer.node, 'div', 'rules', '<b>Правила игры:</b><br> игра на время, выберите, соответствует ли перевод предложенному слову');
     this.score = new ElementTemplate(this.boardContainer.node, 'div', 'sprint__word-count', '0');
     this.board = new Board(this.boardContainer.node);
     this.timer = new ElementTemplate(this.boardContainer.node, 'div', 'sprint__timer', '');
+    new ElementTemplate(this.boardContainer.node, 'div', 'hints', 'Управление с клавиатуры:<br> "Неверно": <b>&#129092;</b>, "Верно": <b>&#129094;</b>');
 
     this.finishWindow = new FinishWindow(null);
 


### PR DESCRIPTION
Добавлен заголовок в игру Аудиовызов, добавлены правила в обе игры, добавлено описание управления с клавиатуры в Спринт.
Пофиксено сужение `header` во время перезагрузки, пока не появился значок логина либо имени пользователя, на разрешении 768px и ниже.
Слегка стало лучше отображение карточек на главной странице с мобильного телефона. С верхней частью еще повоюю, а может и нет. Не понятно, что ломает.

![image](https://user-images.githubusercontent.com/83959481/188649511-a87496ab-b371-4f40-8bb3-ca781076dc0c.png)

